### PR TITLE
Fix for recent Dota 2 files

### DIFF
--- a/src/com/connorhaigh/javavpk/core/Archive.java
+++ b/src/com/connorhaigh/javavpk/core/Archive.java
@@ -76,7 +76,7 @@ public class Archive
 				}
 			}
 			
-			while (true)
+			while (fileInputStream.available()!=0)
 			{
 				//get extension
 				String extension = this.readString(fileInputStream);


### PR DESCRIPTION
Valve recently updated Dota 2 with VPK files that don't work with JavaVPK.  They're missing a null character at the end of the list of directory entries.  This fixes that by checking if there are any bytes left before starting another loop to get the entry.

Note that I haven't tested extensively. There could be cases where this is not the ideal fix - e.g. if you actually want the method to throw an exception, for say an invalid file.  An alternative would be to compare against the length reported in the header.
